### PR TITLE
Add React/Vite/Storybook boilerplate

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,10 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+const config: StorybookConfig = {
+  stories: ['../src/stories/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {}
+  }
+};
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,15 @@
+import type { Preview } from '@storybook/react';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on.*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# codex-Test
+# React + Vite + Storybook Boilerplate
+
+這個範例展示如何建立一個以 **Design System** 為核心的 UI Library。專案採用 [React](https://reactjs.org/)、[Vite](https://vitejs.dev/) 與 [Storybook](https://storybook.js.org/)，並提供簡易的開發腳本與範例組件。
+
+## 目錄結構
+
+```
+.
+├── package.json
+├── vite.config.ts
+├── tsconfig.json
+├── tsconfig.node.json
+├── index.html
+├── src/
+│   ├── main.tsx
+│   ├── App.tsx
+│   ├── components/
+│   │   └── Button.tsx
+│   └── stories/
+│       └── Button.stories.tsx
+└── .storybook/
+    ├── main.ts
+    └── preview.ts
+```
+
+## 快速開始
+1. 安裝依賴：
+
+   ```bash
+   npm install
+   ```
+
+2. 啟動開發伺服器：
+
+   ```bash
+   npm run dev
+   ```
+
+3. 瀏覽 Storybook：
+
+   ```bash
+   npm run storybook
+   ```
+
+## 腳本
+
+- `npm run dev` - 啟動 Vite 開發模式。
+- `npm run build` - 建構產出檔案。
+- `npm run storybook` - 於本地啟動 Storybook。
+- `npm run build-storybook` - 建構靜態版 Storybook，可部署於靜態伺服器。
+
+## 建議
+
+- 透過 Storybook 撰寫每個 UI 元件的 stories，方便設計與工程協作。
+- 保持組件 API 的一致性，並盡量提供良好的型別定義，以提高 DX。
+- 在 `components/` 內撰寫可重複使用的基本元件，並搭配 `stories/` 展示使用情境。
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Design System UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "design-system-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@storybook/react": "^7.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Button } from './components/Button';
+
+export default function App() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Design System UI</h1>
+      <Button label="Hello" />
+    </div>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export interface ButtonProps {
+  label: string;
+}
+
+export const Button: React.FC<ButtonProps> = ({ label }) => {
+  return <button>{label}</button>;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../components/Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Example/Button',
+  component: Button,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof Button> = {
+  args: {
+    label: 'Button',
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["DOM", "ESNext"],
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up minimal React + Vite project
- add Storybook configuration
- include example Button component and story
- document setup and usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d17c4f1b88333af798fd24b29920a